### PR TITLE
Add support for Home Assistant MQTT Discovery

### DIFF
--- a/src/ratgdo.h
+++ b/src/ratgdo.h
@@ -32,6 +32,8 @@ BootstrapManager bootstrapManager;
 
 
 /************* MQTT TOPICS **************************/
+String baseTopic = "";
+
 String doorCommandTopic = ""; // will be mqttTopicPrefix/deviceName/command
 String doorCommand = "";      // will be [open|close|light]
 


### PR DESCRIPTION
NOTE: Opening for feedback; changes needed for arduino_bootstrapper to function completely due to limited fixed MQTT payload size of 256. Changes in arduino_bootstrapper are required to send arbitrary message lengths to work around the payload size. If there is interest in this PR I will open another against arduino_bootstrapper.

This change leverages Home Assistant MQTT Discovery capabilities to automatically create three entities. A cover configured as garage door, a button to toggling the light, and a binary sensor to detect an obstruction.

Still need to make additional changes to support Home Assistant sending "stop" and to handle ratgdo reed_* status. I hope to complete those changes soon.

![hass_entities](https://user-images.githubusercontent.com/1268729/192425704-8fa3cfef-69af-4088-80de-95787657154d.png)
