### PR TITLE
add git ref for Arduino bootstrapper

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_flags =
 lib_deps = 
 	bblanchon/ArduinoJson@^6.19.4
 	knolleary/PubSubClient@^2.8
-	../arduinoImprovBootstrapper
+	git+https://github.com/PaulWieland/arduinoImprovBootstrapper#ratgdo
 
 ; [env:d1_mini_lite_ota]
 ; extends = env:d1_mini_lite


### PR DESCRIPTION
tiny change but helpful so I don't have to maintain a copy of your branch on my machine and other won't mistakenly pull the wrong repo.