### PR TITLE
Add Connections to discovery payload

### DIFF
--- a/src/home_assistant.cpp
+++ b/src/home_assistant.cpp
@@ -34,6 +34,12 @@ void ha_autodiscovery_door(BootstrapManager *bootstrapManager){
 	device["sw_version"] = VERSION;
 	device["configuration_url"] = "http://"+microcontrollerIP+"/";
 
+	// Add MAC as connection ("connections": [["mac", "02:5b:26:a8:dc:12"]])
+	JsonArray connections = device.createNestedArray("connections");
+	JsonArray nested = connections.createNestedArray();
+	nested.add("mac");
+	nested.add(WiFi.macAddress());
+
 	bootstrapManager->publish(topic.c_str(), payload, true);
 }
 
@@ -55,6 +61,13 @@ void ha_autodiscovery_light(BootstrapManager * bootstrapManager){
 	device["model"] = "ratgdo";
 	device["sw_version"] = VERSION;
 	device["configuration_url"] = "http://"+microcontrollerIP+"/";
+	
+	// Add MAC as connection ("connections": [["mac", "02:5b:26:a8:dc:12"]])
+	JsonArray connections = device.createNestedArray("connections");
+	JsonArray nested = connections.createNestedArray();
+	nested.add("mac");
+	nested.add(WiFi.macAddress());
+
 
 	bootstrapManager->publish(topic.c_str(), payload, true);
 }
@@ -79,6 +92,12 @@ void ha_autodiscovery_obs(BootstrapManager *bootstrapManager){
 	device["model"] = "ratgdo";
 	device["sw_version"] = VERSION;
 	device["configuration_url"] = "http://"+microcontrollerIP+"/";
+
+	// Add MAC as connection ("connections": [["mac", "02:5b:26:a8:dc:12"]])
+	JsonArray connections = device.createNestedArray("connections");
+	JsonArray nested = connections.createNestedArray();
+	nested.add("mac");
+	nested.add(WiFi.macAddress());
 
 	bootstrapManager->publish(topic.c_str(), payload, true);
 }


### PR DESCRIPTION
Update the Home Assistant discovery payloads to use the MAC address as the connections, which will allow network tracker integrations (like Unifi) to have their devices linked in Home Assistant.

Reference: https://www.home-assistant.io/integrations/sensor.mqtt/#connections