### PR TITLE
Correcting topic in example for set_code_counter command

### DIFF
--- a/docs/01_features.md
+++ b/docs/01_features.md
@@ -44,7 +44,7 @@ Then:
 
 * mqtt.topic = "home/garage/My Garage Door/command/door"; mqtt.payload = "open"; - opens the door
 * mqtt.topic = "home/garage/My Garage Door/command/door"; mqtt.payload = "close"; - closes the door
-* mqtt.topic = "home/garage/My Garage Door/command/set_code_counter"; mqtt.payload = 537; - sets the rolling code counter to 537
+* mqtt.topic = "home/garage/My Garage Door/set_code_counter"; mqtt.payload = 537; - sets the rolling code counter to 537
 * mqtt.topic = "home/garage/My Garage Door/command"; mqtt.payload = "sync" - syncs the current rolling code counter with the garage door. 
 
 <strong>Notice</strong> Older Security + 2.0 garage door openers with a logic board model# starting with 45 will not accept repeated rolling codes. You must use a rolling code value greater than the last one used with ratgdo. For this reason it is important to take note of the latest rolling code counter (displayed in the serial monitor output) whenever doing a full erase of the esp8266 flash storage.


### PR DESCRIPTION
This topic doesn't include the `command/` part of the path.

from ratgdo.cpp:
```
	setCounterTopic = String(mqttTopicPrefix) + deviceName + "/set_code_counter";
```